### PR TITLE
Feature: Remove NPM_TOKEN from npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 scope=friendsofreactjs


### PR DESCRIPTION
The NPM_TOKEN environment variable leads to problems with the local development.
If you don`t define the NPM_TOKEN in your ~/.profile or if you don`t pass it thru.

I am not sure if it is possible to use this conditionally ... so as temporary solution I just drop it.
That makes it easier to contribute and work locally with the package.