### PR TITLE
BUGFIX: fix support for stateful React components with TypeScript by making props mandatory

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,6 @@ declare module "@friendsofreactjs/react-css-themr" {
     identifier: string | number | symbol,
     defaultTheme?: {},
     options?: IThemrOptions
-  ): <P, S>(component: (new(props?: P, context?: any) => React.Component<P, S>) | React.SFC<P>) =>
+  ): <P, S>(component: (new(props: P, context?: any) => React.Component<P, S>) | React.SFC<P>) =>
     ThemedComponentClass<P & { mapThemrProps?: TMapThemrProps<P> }, S>;
 }


### PR DESCRIPTION
WARNING: I'm a TS n00b, this is my first day with it.

Take a simple class-based react component and try to wrap it with themr:

```ts
import React from 'react';
import {themr} from '@friendsofreactjs/react-css-themr';

interface LabelProps {
    [x: string]: any;
}

class Label extends React.Component<LabelProps> {
    render() {
        return <div/>;
    }
}

themr('123', {})(Label);
```

You'd get an error:
```
[ts]
Argument of type 'typeof Label' is not assignable to parameter of type '(new (props?: LabelProps | undefined, context?: any) => Component<LabelProps, {}, any>) | StatelessComponent<LabelProps>'.
  Type 'typeof Label' is not assignable to type 'StatelessComponent<LabelProps>'.
    Type 'typeof Label' provides no match for the signature '(props: LabelProps & { children?: ReactNode; }, context?: any): ReactElement<any> | null'.
```

This happens because themr defines props as optional where as `@type/react` defines it as mandatory: `new (props: P, context?: any): Component<P, S>;` .