### PR TITLE
Bugfix - Inner ref

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,6 @@ declare module "@friendsofreactjs/react-css-themr" {
   }
 
   export interface ThemeProviderProps {
-    innerRef?: Function,
     theme: TReactCSSThemrTheme
   }
 
@@ -35,6 +34,6 @@ declare module "@friendsofreactjs/react-css-themr" {
     identifier: string | number | symbol,
     defaultTheme?: {},
     options?: IThemrOptions
-  ): <P, S>(component: (new(props: P, context?: any) => React.Component<P, S>) | React.SFC<P>) =>
-    ThemedComponentClass<P & { mapThemrProps?: TMapThemrProps<P> }, S>;
+  ): <P, S, R>(component: (new(props: P, context?: any) => React.Component<P, S>) | React.SFC<P>) =>
+    ThemedComponentClass<P & { mapThemrProps?: TMapThemrProps<P>, innerRef?: React.Ref<R> }, S>;
 }

--- a/lib/components/themr.js
+++ b/lib/components/themr.js
@@ -196,7 +196,7 @@ var _default = function _default(componentName, localTheme) {
 
     _defineProperty(Themed, "propTypes", _objectSpread({}, ThemedComponent.propTypes, {
       composeTheme: _propTypes["default"].oneOf([COMPOSE_DEEPLY, COMPOSE_SOFTLY, DONT_COMPOSE]),
-      innerRef: _propTypes["default"].func,
+      innerRef: _propTypes["default"].oneOfType([_propTypes["default"].func, _propTypes["default"].object]),
       theme: _propTypes["default"].object,
       themeNamespace: _propTypes["default"].string,
       mapThemrProps: _propTypes["default"].func

--- a/src/components/themr.js
+++ b/src/components/themr.js
@@ -70,7 +70,7 @@ export default (componentName, localTheme, options = {}) => ThemedComponent => {
         COMPOSE_SOFTLY,
         DONT_COMPOSE
       ]),
-      innerRef: PropTypes.func,
+      innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
       theme: PropTypes.object,
       themeNamespace: PropTypes.string,
       mapThemrProps: PropTypes.func


### PR DESCRIPTION
- Fix console error when using `React.createRef`
- `innerRef` was incorrectly applied to the `ThemeProvider` component